### PR TITLE
rechartsのtooltipスタイル調整

### DIFF
--- a/src/app/_components/client/PrefGraph.tsx
+++ b/src/app/_components/client/PrefGraph.tsx
@@ -13,6 +13,7 @@ import {
 import { PopulationData } from '@/app/_utils/get-population';
 import { useSearchParams } from 'next/navigation';
 import { getPrefCodes } from '@/app/_utils/query-parameter';
+import { css } from '@kuma-ui/core';
 
 export const revalidate = 3600;
 
@@ -50,15 +51,27 @@ export default function PrefGraph({
         data={data}
         margin={{
           top: 5,
-          right: 30,
-          left: 20,
+          right: 20,
+          left: 30,
           bottom: 5,
         }}
       >
         <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="year" />
-        <YAxis />
-        <Tooltip />
+        <XAxis dataKey="year" unit={'年'} />
+        <YAxis tickFormatter={(value: number) => value.toLocaleString()} />
+        <Tooltip
+          wrapperClassName={css`
+            > ul {
+              max-height: 400px;
+              display: flex;
+              flex-direction: column;
+              font-size: 0.75rem;
+              flex-wrap: wrap;
+            }
+          `}
+          labelFormatter={(value: number) => `${value}年`}
+          formatter={(value: number) => `${value.toLocaleString()}人`}
+        />
         <Legend />
         {filtered.map((pref) => (
           <Line


### PR DESCRIPTION
## Issue

- Github Issue: #39 

## 変更内容
Tooltipのスタイリングと数値にカンマと単位を追加

## スクリーンショット
![image](https://github.com/takecchi/japan-population-viewer/assets/68576095/9d85f61e-5240-4c12-bd25-63255b7d9e91)


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- スタイル: `PrefGraph` コンポーネントの視覚的な改善を行いました。具体的には、X軸に年の単位を追加し、Y軸の数値をカンマ区切りで表示するように変更しました。
- 新機能: Tooltipのスタイリングを調整し、表示される数値に単位を追加しました。これにより、ユーザーはデータをより直感的に理解できるようになります。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->