### PR TITLE
クエリパラメータの変更でブラウザ履歴が残らないよう改修

### DIFF
--- a/src/app/_components/client/PrefCheckbox.tsx
+++ b/src/app/_components/client/PrefCheckbox.tsx
@@ -29,7 +29,7 @@ export default function PrefCheckbox({ label, prefCode }: Props) {
           // チェックが外された場合、prefCode を削除
           updatedPrefCodes = prefCodes.filter((code) => code !== prefCode);
         }
-        router.push(`?${createQueryString(updatedPrefCodes)}`, {
+        router.replace(`?${createQueryString(updatedPrefCodes)}`, {
           scroll: false,
         });
       }}


### PR DESCRIPTION
## 変更内容
`router.push`でクエリパラメータの変更がブラウザの履歴に残るようになっていたが、残さないように変更

@coderabbitai: ignore
